### PR TITLE
feat: dir property, utilize path.join

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 
-import { extname, basename, dirname, sep } from 'path';
+import { extname, basename, dirname, sep, join } from 'path';
 
 export class FilePath {
   /** The string representing the file name excluding the extension */
@@ -28,7 +28,15 @@ export class FilePath {
 
   /** Get: the current path */
   public get path(): string {
-    return `${this.folders.join(sep)}${sep}${this.file ? this.file : ''}`;
+    return join(this.folders.join(sep), this.file ? this.file : sep);
+  }
+
+  public get dir(): string {
+    return join(this.folders.join(sep));
+  }
+
+  public set dir(dir: string) {
+    this.path = join(dir, this.file ? this.file : '');
   }
 
   /** Set: the full file name including the extension */

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -31,10 +31,12 @@ export class FilePath {
     return join(this.folders.join(sep), this.file ? this.file : sep);
   }
 
+  /** Get: the current directory */
   public get dir(): string {
     return join(this.folders.join(sep));
   }
 
+  /** Set: change the current directory */
   public set dir(dir: string) {
     this.path = join(dir, this.file ? this.file : '');
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,7 +7,7 @@ export class FilePath {
   public filename: string | undefined;
 
   /** An ordered array of folder names. folders[0] represents the root of the path.
-   * If absolute, it will be an empty string (required), if relative, it will be the folder reference '.' or '..'
+   * If absolute, it will be an empty string (required), if relative it will be the first folder, '.', or '..'
    */
   public folders: string[] = [];
 
@@ -33,12 +33,13 @@ export class FilePath {
 
   /** Get: the current directory */
   public get dir(): string {
+    // Inner .join to keep the root empty string delimiter if present
     return join(this.folders.join(sep));
   }
 
   /** Set: change the current directory */
   public set dir(dir: string) {
-    this.path = join(dir, this.file ? this.file : '');
+    this.folders = dir.split(sep);
   }
 
   /** Set: the full file name including the extension */

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,25 @@ console.log(path.file, path.filename, path.extension, path.path);
 > 'this/is/a/new'
 ```
 
+### dir
+
+Set: change the directory (without the file)
+Get: get the directory (without the file)
+
+```js
+const path = new FilePath('this/is/a/file.jpeg');
+path.dir = '/this/is/the'
+
+console.log(path.dir, path.file, path.filename, path.extension, path.path);
+
+> '/this/is/the'
+> 'new.jpeg'
+> 'new'
+> 'jpeg'
+> 'this/is/the/new.jpeg'
+
+```
+
 ### filename
 
 Set: set the filename (without extension)  
@@ -92,7 +111,9 @@ console.log(path.extension, path.file, path.path);
 
 ### folders
 
-An ordered array of folder names. folders[0] represents the root of the path. If absolute, it will be empty '' (required), if relative, it will be the first folder, or reference '.' or '..'
+An ordered array of folder names. folders[0] represents the root of the path. If absolute, it will be empty '' (required), if relative, it will be the first folder, or reference '.' or '..'.
+
+The recommended use it to change a specific folder in the path, using the index.
 
 ```js
 const path = new FilePath('/this/is/a/file.jpeg');
@@ -100,10 +121,10 @@ console.log(path.folders);
 
 > ['', 'this', 'is', 'a']
 
-path.path = 'this/is/a/file.jpeg';
+path.path = 'this/is/the/file.jpeg';
 console.log(path.folders);
 
-> ['this', 'is', 'a']
+> ['this', 'is', 'the']
 
 path.folders.unshift('..');
 path.folders[path.folders.length - 1] = 'relative';

--- a/readme.md
+++ b/readme.md
@@ -69,10 +69,10 @@ path.dir = '/this/is/the'
 console.log(path.dir, path.file, path.filename, path.extension, path.path);
 
 > '/this/is/the'
-> 'new.jpeg'
-> 'new'
+> 'file.jpeg'
+> 'file'
 > 'jpeg'
-> 'this/is/the/new.jpeg'
+> 'this/is/the/file.jpeg'
 
 ```
 

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -71,13 +71,13 @@ describe('FilePath', () => {
 
   it('sets directory independent of the file', () => {
     const path = new FilePath('/this/is/the/original_file.pdf');
-    path.dir = '/new/location';
+    path.dir = 'new/location';
 
     expect(path.extension).toEqual('pdf');
     expect(path.filename).toEqual('original_file');
     expect(path.file).toEqual('original_file.pdf');
-    expect(path.path).toEqual('/new/location/original_file.pdf');
-    expect(path.dir).toEqual('/new/location');
+    expect(path.path).toEqual('new/location/original_file.pdf');
+    expect(path.dir).toEqual('new/location');
   });
 
   it('can clear out a file completely', () => {

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -9,6 +9,7 @@ describe('FilePath', () => {
     expect(path.extension).toEqual('jpeg');
     expect(path.file).toEqual('path.jpeg');
     expect(path.path).toEqual('/this/is/a/full/path.jpeg');
+    expect(path.dir).toEqual('/this/is/a/full');
   });
 
   it('parses a relative path', () => {
@@ -19,6 +20,7 @@ describe('FilePath', () => {
     expect(path.extension).toEqual('jpeg');
     expect(path.file).toEqual('path.jpeg');
     expect(path.path).toEqual('this/is/a/full/path.jpeg');
+    expect(path.dir).toEqual('this/is/a/full');
 
     path.folders.unshift('.');
     path.folders[path.folders.length - 1] = 'relative';
@@ -27,6 +29,17 @@ describe('FilePath', () => {
     path.folders[0] = '..';
     expect(path.folders).toEqual(['..', 'this', 'is', 'a', 'relative']);
     expect(path.path).toEqual('../this/is/a/relative/path.jpeg');
+  });
+
+  it('normalizes path', () => {
+    const path = new FilePath('this/is/../is/../is/./a/full/path.jpeg');
+
+    expect(path.folders).toEqual(['this', 'is', '..', 'is', '..', 'is', '.', 'a', 'full']);
+    expect(path.filename).toEqual('path');
+    expect(path.extension).toEqual('jpeg');
+    expect(path.file).toEqual('path.jpeg');
+    expect(path.path).toEqual('this/is/a/full/path.jpeg');
+    expect(path.dir).toEqual('this/is/a/full');
   });
 
   it('handles an extensionless path', () => {
@@ -53,6 +66,18 @@ describe('FilePath', () => {
     expect(path.filename).toEqual('thumbnail_low');
     expect(path.file).toEqual('thumbnail_low.jpeg');
     expect(path.path).toEqual('/this/is/the/thumbnail_low.jpeg');
+    expect(path.dir).toEqual('/this/is/the');
+  });
+
+  it('sets directory independent of the file', () => {
+    const path = new FilePath('/this/is/the/original_file.pdf');
+    path.dir = '/new/location';
+
+    expect(path.extension).toEqual('pdf');
+    expect(path.filename).toEqual('original_file');
+    expect(path.file).toEqual('original_file.pdf');
+    expect(path.path).toEqual('/new/location/original_file.pdf');
+    expect(path.dir).toEqual('/new/location');
   });
 
   it('can clear out a file completely', () => {


### PR DESCRIPTION
Adds a `dir` property to get the full path of the directory for the given FilePath instance. Mirrors `file`.

Uses `path.join` when building `path`, and `dir` to normalize `..` and `.`. These are kept in `folders` for posterity.